### PR TITLE
Add configuration option for extended durations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ license-file = "LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+xml5ever = "0.16.1"
+markup5ever_rcdom = "0.1.0"

--- a/Config.xml
+++ b/Config.xml
@@ -1,3 +1,3 @@
 <configuration>
-	<extended>false</extended>
+  <extend>false</extend>
 </configuration>

--- a/Config.xml
+++ b/Config.xml
@@ -1,0 +1,3 @@
+<configuration>
+	<extended>false</extended>
+</configuration>

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use markup5ever_rcdom::{Handle, NodeData, RcDom};
+
+use xml5ever::driver::parse_document;
+use xml5ever::tendril::TendrilSink;
+
+pub struct Config {
+    duration: Duration,
+}
+
+impl Config {
+    pub fn parse(config: &str) -> Self {
+        let parser = parse_document(RcDom::default(), Default::default());
+
+        let dom = parser.one(config);
+        let doc = dom.document.clone();
+
+        let duration = if Self::is_extended(doc) {
+            Duration::from_secs(60 * 60 * 24 * 365 * 3 + 1)
+        } else {
+            Duration::from_secs(60 * 60 * 24 * 365 * 3)
+        };
+
+        Config { duration }
+    }
+
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    fn is_extended(doc: Handle) -> bool {
+        for node in doc.children.borrow().iter() {
+            if let Some(node) = Self::find_extended_node(node.clone()) {
+                if let Some(text) = Self::find_extended_value(node) {
+                    return text == "true";
+                }
+            };
+        }
+
+        false
+    }
+
+    fn find_extended_node(config: Handle) -> Option<Handle> {
+        let children = &*config.children.borrow();
+
+        let matches = children.iter().find(|node| {
+            if let NodeData::Element { name, .. } = &node.data {
+                &name.local == "extended"
+            } else {
+                false
+            }
+        });
+
+        matches.map(|rc| rc.clone())
+    }
+
+    fn find_extended_value(node: Handle) -> Option<String> {
+        let children = &*node.children.borrow();
+
+        let mut iter = children.iter().filter_map(|node| {
+            if let NodeData::Text { contents } = &node.data {
+                Some(contents)
+            } else {
+                None
+            }
+        });
+
+        iter.next().map(|c| c.borrow().to_string())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,3 +65,35 @@ impl Config {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use super::{SECONDS, Config};
+
+    const TEMPLATE: &str = r#"
+        <configuration>
+            <extend>{}</extend>
+        </configuration>
+    "#;
+
+    #[test]
+    fn test_normal_duration() {
+        let text = TEMPLATE.replace("{}", "false");
+        let config = Config::new(&text);
+
+        let expected = Duration::from_secs(SECONDS);
+
+        assert_eq!(expected, config.duration());
+    }
+
+    #[test]
+    fn test_extended_duration() {
+        let text = TEMPLATE.replace("{}", "true");
+        let config = Config::new(&text);
+
+        let expected = Duration::from_secs(SECONDS + 1);
+
+        assert_eq!(expected, config.duration());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use self::config::Config;
 const CONFIG: &str = include_str!("../Config.xml");
 
 pub fn brexit<T>(o: T) where T: Sync+Send+'static {
-    let config = Config::parse(CONFIG);
+    let config = Config::new(CONFIG);
     let duration = config.duration();
 
     thread::spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,17 @@
+mod config;
+
 use std::thread;
-use std::time::Duration;
+
+use self::config::Config;
+
+const CONFIG: &str = include_str!("../Config.xml");
 
 pub fn brexit<T>(o: T) where T: Sync+Send+'static {
+    let config = Config::parse(CONFIG);
+    let duration = config.duration();
+
     thread::spawn(move || {
-        thread::sleep(Duration::from_secs(60*60*24*365*3));
+        thread::sleep(duration);
         drop(o)
     });
 }


### PR DESCRIPTION
While using this crate in production we ran into an issue where it would trigger Brexit one second too early due to a faulty system clock. This pull request adds a workaround that makes it easy to configure the timer without writing even a single line of Rust!

For this we're using the battle-tested [markup5ever_rcdom](https://crates.io/crates/markup5ever_rcdom/0.1.0) create. This comes with the added benefit of being able to add more XML-based configuration in the future.

It might seem a bit silly to include the configuration with built binaries. We do this because we're actually maintaining an internal fork of your library, but still want to stay as close to upstream as possible. This way we can have the same general code base, but keep the setting checked into our repository.